### PR TITLE
Tweak 2018 main content top margin

### DIFF
--- a/2018/index.html
+++ b/2018/index.html
@@ -73,7 +73,7 @@ redirect_to: https://vimconf.org/2018/
       </div>
     </nav>
 
-    <main role="main">
+    <main role="main" class="mt-5">
 
       <!-- Main jumbotron for a primary marketing message or call to action -->
       <div class="jumbotron">


### PR DESCRIPTION
https://vimconf.org/2018/ をスマホで見た際にnavbarと下の内容が重なっていたので、重ならないようにしてみました。
こちらで確認できます。https://y0za.github.io/vimconf/2018/
個別に適用しているstylesheetが見当たらなかったのでBootstrapのSpacingで対応しましたが、navbarの高さ分ちょうどmarginを設けるには `magin-top: 3.5rem;` を適用するといいかと思います。

Before
<img width="417" alt="vimconf_2018_before" src="https://user-images.githubusercontent.com/16757772/42231653-177aa2a4-7f27-11e8-87f2-779e15552b98.png">

After
<img width="409" alt="vimconf_2018_after" src="https://user-images.githubusercontent.com/16757772/42231671-1e443bd6-7f27-11e8-8362-e9c28b8c1fd9.png">
