### PR TITLE
Tweak 2018 background image size

### DIFF
--- a/2018/index.html
+++ b/2018/index.html
@@ -77,7 +77,7 @@ redirect_to: https://vimconf.org/2018/
     <main role="main" class="mt-5">
 
       <!-- Main jumbotron for a primary marketing message or call to action -->
-      <div class="jumbotron">
+      <div id="description-box" class="jumbotron">
         <div id="description" class="container">
           <h1 class="display-3">VimConf 2018</h1>
           <p>at <a href="https://www.fsi.co.jp/e/solutions/other_solutions/akibaplaza/">Fujisoft Akiba Hall in Tokyo, Japan</a> on Nov 24, 2018</p>

--- a/2018/style.css
+++ b/2018/style.css
@@ -1,6 +1,11 @@
-#description {
+#description-box {
 	background-image: url(vimconf2017-akibaplaza.jpg);
-	background-size: 100%;
+	background-repeat: no-repeat;
+	background-size: cover;
+	background-position-x: center;
+}
+
+#description {
 	padding: 1em;
 }
 


### PR DESCRIPTION
背景画像の周りに隙間がない方が良さそうだと思って、そうなるようにしてみました。
https://y0za.github.io/vimconf/2018/ こちらで確認できるので、もしよろしければ使ってください。
特にスマホサイズだと画像の粗さが目立つ気がするので、画像を差し替えるなりblurをかけるなり手を加える必要があるかもしれないです。